### PR TITLE
Example sketches: Avoid double negatives and correct &'s to &&

### DIFF
--- a/examples/GPRSPing/GPRSPing.ino
+++ b/examples/GPRSPing/GPRSPing.ino
@@ -39,14 +39,14 @@ void setup() {
 
  Serial.println("Starting Arduino GPRS ping.");
  // connection state
- boolean notConnected = true;
+ boolean connected = false;
 
  // After starting the modem with GSM.begin()
  // attach the shield to the GPRS network with the APN, login and password
- while (notConnected) {
-   if ((gsmAccess.begin(PINNUMBER) == GSM_READY) &
+ while (!connected) {
+   if ((gsmAccess.begin(PINNUMBER) == GSM_READY) &&
        (gprs.attachGPRS(GPRS_APN, GPRS_LOGIN, GPRS_PASSWORD) == GPRS_READY)) {
-     notConnected = false;
+     connected = true;
    } else {
      Serial.println("Not connected");
      delay(1000);

--- a/examples/GPRSUdpNtpClient/GPRSUdpNtpClient.ino
+++ b/examples/GPRSUdpNtpClient/GPRSUdpNtpClient.ino
@@ -56,14 +56,14 @@ void setup()
 
   Serial.println("Starting Arduino GPRS NTP client.");
   // connection state
-  boolean notConnected = true;
+  boolean connected = false;
 
   // After starting the modem with GSM.begin()
   // attach the shield to the GPRS network with the APN, login and password
-  while (notConnected) {
-    if ((gsmAccess.begin(PINNUMBER) == GSM_READY) &
+  while (!connected) {
+    if ((gsmAccess.begin(PINNUMBER) == GSM_READY) &&
         (gprs.attachGPRS(GPRS_APN, GPRS_LOGIN, GPRS_PASSWORD) == GPRS_READY)) {
-      notConnected = false;
+      connected = true;
     } else {
       Serial.println("Not connected");
       delay(1000);

--- a/examples/GsmLocation/GsmLocation.ino
+++ b/examples/GsmLocation/GsmLocation.ino
@@ -40,14 +40,14 @@ void setup() {
 
   Serial.println("Starting GSM location.");
   // connection state
-  boolean notConnected = true;
+  boolean connected = false;
 
   // After starting the modem with GSM.begin()
   // attach the shield to the GPRS network with the APN, login and password
-  while (notConnected) {
-    if ((gsmAccess.begin(PINNUMBER) == GSM_READY) &
+  while (!connected) {
+    if ((gsmAccess.begin(PINNUMBER) == GSM_READY) &&
         (gprs.attachGPRS(GPRS_APN, GPRS_LOGIN, GPRS_PASSWORD) == GPRS_READY)) {
-      notConnected = false;
+      connected = true;
     } else {
       Serial.println("Not connected");
       delay(1000);

--- a/examples/GsmSSLWebClient/GsmSSLWebClient.ino
+++ b/examples/GsmSSLWebClient/GsmSSLWebClient.ino
@@ -45,14 +45,14 @@ void setup() {
 
   Serial.println("Starting Arduino web client.");
   // connection state
-  boolean notConnected = true;
+  boolean connected = false;
 
   // After starting the modem with GSM.begin()
   // attach the shield to the GPRS network with the APN, login and password
-  while (notConnected) {
-    if ((gsmAccess.begin(PINNUMBER) == GSM_READY) &
+  while (!connected) {
+    if ((gsmAccess.begin(PINNUMBER) == GSM_READY) &&
         (gprs.attachGPRS(GPRS_APN, GPRS_LOGIN, GPRS_PASSWORD) == GPRS_READY)) {
-      notConnected = false;
+      connected = true;
     } else {
       Serial.println("Not connected");
       delay(1000);

--- a/examples/GsmWebClient/GsmWebClient.ino
+++ b/examples/GsmWebClient/GsmWebClient.ino
@@ -45,14 +45,14 @@ void setup() {
 
   Serial.println("Starting Arduino web client.");
   // connection state
-  boolean notConnected = true;
+  boolean connected = false;
 
   // After starting the modem with GSM.begin()
   // attach the shield to the GPRS network with the APN, login and password
-  while (notConnected) {
-    if ((gsmAccess.begin(PINNUMBER) == GSM_READY) &
+  while (!connected) {
+    if ((gsmAccess.begin(PINNUMBER) == GSM_READY) &&
         (gprs.attachGPRS(GPRS_APN, GPRS_LOGIN, GPRS_PASSWORD) == GPRS_READY)) {
-      notConnected = false;
+      connected = true;
     } else {
       Serial.println("Not connected");
       delay(1000);

--- a/examples/GsmWebServer/GsmWebServer.ino
+++ b/examples/GsmWebServer/GsmWebServer.ino
@@ -42,14 +42,14 @@ void setup() {
   }
 
   // connection state
-  boolean notConnected = true;
+  boolean connected = false;
 
   // Start GSM shield
   // If your SIM has PIN, pass it as a parameter of begin() in quotes
-  while (notConnected) {
-    if ((gsmAccess.begin(PINNUMBER) == GSM_READY) &
+  while (!connected) {
+    if ((gsmAccess.begin(PINNUMBER) == GSM_READY) &&
         (gprs.attachGPRS(GPRS_APN, GPRS_LOGIN, GPRS_PASSWORD) == GPRS_READY)) {
-      notConnected = false;
+      connected = true;
     } else {
       Serial.println("Not connected");
       delay(1000);

--- a/examples/MakeVoiceCall/MakeVoiceCall.ino
+++ b/examples/MakeVoiceCall/MakeVoiceCall.ino
@@ -43,13 +43,13 @@ void setup() {
   Serial.println("Make Voice Call");
 
   // connection state
-  boolean notConnected = true;
+  boolean connected = false;
 
   // Start GSM shield
   // If your SIM has PIN, pass it as a parameter of begin() in quotes
-  while (notConnected) {
+  while (!connected) {
     if (gsmAccess.begin(PINNUMBER) == GSM_READY) {
-      notConnected = false;
+      connected = true;
     } else {
       Serial.println("Not connected");
       delay(1000);

--- a/examples/ReceiveSMS/ReceiveSMS.ino
+++ b/examples/ReceiveSMS/ReceiveSMS.ino
@@ -38,12 +38,12 @@ void setup() {
   Serial.println("SMS Messages Receiver");
 
   // connection state
-  boolean notConnected = true;
+  boolean connected = false;
 
   // Start GSM connection
-  while (notConnected) {
+  while (!connected) {
     if (gsmAccess.begin(PINNUMBER) == GSM_READY) {
-      notConnected = false;
+      connected = true;
     } else {
       Serial.println("Not connected");
       delay(1000);

--- a/examples/ReceiveVoiceCall/ReceiveVoiceCall.ino
+++ b/examples/ReceiveVoiceCall/ReceiveVoiceCall.ino
@@ -38,13 +38,13 @@ void setup() {
   Serial.println("Receive Voice Call");
 
   // connection state
-  boolean notConnected = true;
+  boolean connected = false;
 
   // Start GSM shield
   // If your SIM has PIN, pass it as a parameter of begin() in quotes
-  while (notConnected) {
+  while (!connected) {
     if (gsmAccess.begin(PINNUMBER) == GSM_READY) {
-      notConnected = false;
+      connected = true;
     } else {
       Serial.println("Not connected");
       delay(1000);

--- a/examples/SendSMS/SendSMS.ino
+++ b/examples/SendSMS/SendSMS.ino
@@ -39,13 +39,13 @@ void setup() {
   Serial.println("SMS Messages Sender");
 
   // connection state
-  boolean notConnected = true;
+  boolean connected = false;
 
   // Start GSM shield
   // If your SIM has PIN, pass it as a parameter of begin() in quotes
-  while (notConnected) {
+  while (!connected) {
     if (gsmAccess.begin(PINNUMBER) == GSM_READY) {
-      notConnected = false;
+      connected = true;
     } else {
       Serial.println("Not connected");
       delay(1000);

--- a/examples/Tools/GsmScanNetworks/GsmScanNetworks.ino
+++ b/examples/Tools/GsmScanNetworks/GsmScanNetworks.ino
@@ -48,13 +48,13 @@ void setup() {
   scannerNetworks.begin();
 
   // connection state
-  boolean notConnected = true;
+  boolean connected = false;
 
   // Start GSM shield
   // If your SIM has PIN, pass it as a parameter of begin() in quotes
-  while (notConnected) {
+  while (!connected) {
     if (gsmAccess.begin(PINNUMBER) == GSM_READY) {
-      notConnected = false;
+      connected = true;
     } else {
       Serial.println("Not connected");
       delay(1000);

--- a/examples/Tools/TestWebServer/TestWebServer.ino
+++ b/examples/Tools/TestWebServer/TestWebServer.ino
@@ -42,7 +42,7 @@ void setup() {
 
   Serial.println("starting,..");
   // connection state
-  boolean connected = true;
+  boolean connected = false;
 
   // Start GSM shield
   // If your SIM has PIN, pass it as a parameter of begin() in quotes


### PR DESCRIPTION
@cmaglie as discussed:

- Avoid using double negatives in example sketches (`!notConnected`)
- Replaces bit wise `&` with logical `&&`