### PR TITLE
Low power fixes

### DIFF
--- a/src/GSMPIN.cpp
+++ b/src/GSMPIN.cpp
@@ -35,7 +35,7 @@ int GSMPIN::isPIN()
 {
   String response;
 
-  for (unsigned long start = millis(); millis() < (start + 1000);) {
+  for (unsigned long start = millis(); (millis() - start) < 1000;) {
     MODEM.send("AT+CPIN?");
 
     if (MODEM.waitForResponse(10000, &response) == 1) {
@@ -124,7 +124,7 @@ void GSMPIN::switchPIN(String pin)
 
 int GSMPIN::checkReg()
 {
-  for (unsigned long start = millis(); millis() < (start + 10000L);) {
+  for (unsigned long start = millis(); (millis() - start) < 10000L;) {
     MODEM.send("AT+CREG?");
 
     String response = "";

--- a/src/GSMVoiceCall.cpp
+++ b/src/GSMVoiceCall.cpp
@@ -63,7 +63,7 @@ int GSMVoiceCall::voiceCall(const char* to, unsigned long timeout)
     }
 
     _callStatus = CALLING;
-    for (unsigned long start = millis(); (timeout == 0) || (millis() < (start + timeout));) {
+    for (unsigned long start = millis(); (timeout == 0) || ((millis() - start) < timeout);) {
       if (getvoiceCallStatus() != CALLING) {
         break;
       }

--- a/src/Modem.cpp
+++ b/src/Modem.cpp
@@ -163,6 +163,7 @@ void ModemClass::send(const char* command)
 {
   if (_lowPowerMode) {
     digitalWrite(_dtrPin, LOW);
+    delay(5);
   }
 
   _uart->println(command);

--- a/src/Modem.cpp
+++ b/src/Modem.cpp
@@ -103,7 +103,7 @@ void ModemClass::debug()
 
 int ModemClass::autosense(int timeout)
 {
-  for (unsigned long start = millis(); millis() < (start + timeout);) {
+  for (unsigned long start = millis(); (millis() - start) < timeout;) {
     if (noop() == 1) {
       return 1;
     }
@@ -186,7 +186,7 @@ void ModemClass::sendf(const char *fmt, ...)
 int ModemClass::waitForResponse(unsigned long timeout, String* responseDataStorage)
 {
   _responseDataStorage = responseDataStorage;
-  for (unsigned long start = millis(); millis() < (start + timeout);) {
+  for (unsigned long start = millis(); (millis() - start) < timeout;) {
     int r = ready();
 
     if (r != 0) {


### PR DESCRIPTION
When low power mode, the module needs a bit more time to wake up even though CTS is set. This PR adds a 5ms delay before sending the AT command in low power mode.

I've also made some changes to correctly handle `millis()` rollover scenarios, as @cmaglie mentioned when he looked at the code.