### PR TITLE
Use socket URC's to determine available socket data

### DIFF
--- a/src/GSMClient.h
+++ b/src/GSMClient.h
@@ -24,7 +24,6 @@
 
 #include "Modem.h"
 
-
 class GSMClient : public Client, public ModemUrcHandler {
 
 public:
@@ -146,6 +145,7 @@ private:
   bool _writeSync;
   String _response;
   int _peek;
+  int _available;
 };
 
 #endif

--- a/src/GSMServer.h
+++ b/src/GSMServer.h
@@ -103,6 +103,7 @@ private:
   struct {
     int socket;
     bool accepted;
+    int available;
   } _childSockets[MAX_CHILD_SOCKETS];
 };
 

--- a/src/GSMUdp.h
+++ b/src/GSMUdp.h
@@ -22,10 +22,14 @@
 
 #include <Udp.h>
 
-class GSMUDP : public UDP {
+#include "Modem.h"
+
+class GSMUDP : public UDP, public ModemUrcHandler {
 
 public:
   GSMUDP();  // Constructor
+  virtual ~GSMUDP();
+
   virtual uint8_t begin(uint16_t);  // initialize, start listening on specified port. Returns 1 if successful, 0 if there are no sockets available to use
   virtual void stop();  // Finish with the UDP socket
 
@@ -69,8 +73,11 @@ public:
   // Return the port of the host who sent the current incoming packet
   virtual uint16_t remotePort();
 
+  virtual void handleUrc(const String& urc);
+
 private:
   int _socket;
+  bool _packetReceived;
 
   IPAddress _txIp;
   const char* _txHost;

--- a/src/Modem.h
+++ b/src/Modem.h
@@ -76,7 +76,7 @@ private:
   String _buffer;
   String* _responseDataStorage;
 
-  #define MAX_URC_HANDLERS 10
+  #define MAX_URC_HANDLERS 10 // 7 sockets + GPRS + GSMLocation + GSMVoiceCall
   static bool _debug;
   static ModemUrcHandler* _urcHandlers[MAX_URC_HANDLERS];
 };


### PR DESCRIPTION
I think this will help with #10 and #11.

From section 25.12.1 of the u-blox AT command manual:
> For the TCP socket type the URC +UUSORD: <socket>,<length> notifies the data bytes available for reading, either when buffer is empty and new data arrives or after a partial read by the user.

and section:
>  The URC +UUSORF: <socket>,<length> (or also +UUSORD: <socket>,<length>) notifies that new data is available for reading, either when new data arrives or after a partial read by the user for the socket. 

These change leverage these URC's instead of using the `AT+USORD` or `AT+USORF` commands to poll for data available. So, the modem is not hammered with commands.

The `GSMWebClient` example is now > 50% faster in my tests (~9s vs ~19s).