### PR TITLE
Add new GPRS::status() API

### DIFF
--- a/src/GPRS.cpp
+++ b/src/GPRS.cpp
@@ -358,6 +358,13 @@ int GPRS::ping(IPAddress ip, uint8_t ttl)
   return ping(host, ttl);
 }
 
+GSM3_NetworkStatus_t GPRS::status()
+{
+  MODEM.poll();
+
+  return _status;
+}
+
 void GPRS::handleUrc(const String& urc)
 {
   if (urc.startsWith("+UUPINGER: ")) {
@@ -379,6 +386,13 @@ void GPRS::handleUrc(const String& urc)
       } else if (_pingResult <= 0) {
         _pingResult = GPRS_PING_ERROR;
       }
+    }
+  } else if (urc.startsWith("+UUPSDD: ")) {
+    int profileId = urc.charAt(urc.length() - 1) - '0';
+
+    if (profileId == 0) {
+      // disconnected
+      _status = IDLE;
     }
   }
 }

--- a/src/GPRS.cpp
+++ b/src/GPRS.cpp
@@ -326,8 +326,12 @@ int GPRS::ping(const char* hostname, uint8_t ttl)
     return GPRS_PING_ERROR;
   };
 
-  while (_pingResult == 0) {
+  for (unsigned long start = millis(); (millis() - start) < 5000 && (_pingResult == 0);) {
     MODEM.poll();
+  }
+
+  if (_pingResult == 0) {
+    _pingResult = GPRS_PING_TIMEOUT;
   }
 
   return _pingResult;

--- a/src/GPRS.h
+++ b/src/GPRS.h
@@ -88,6 +88,8 @@ public:
   int ping(const String& hostname, uint8_t ttl = 128);
   int ping(IPAddress ip, uint8_t ttl = 128);
 
+  GSM3_NetworkStatus_t status();
+
   void handleUrc(const String& urc);
 
 private:

--- a/src/GSM.cpp
+++ b/src/GSM.cpp
@@ -76,7 +76,18 @@ GSM3_NetworkStatus_t GSM::begin(const char* pin, bool restart, bool synchronous)
 
 int GSM::isAccessAlive()
 {
-  return (MODEM.noop() == 1 ? 1 : 0);
+  String response;
+
+  MODEM.send("AT+CREG?");
+  if (MODEM.waitForResponse(100, &response) == 1) {
+    int status = response.charAt(response.length() - 1) - '0';
+
+    if (status == 1 || status == 5 || status == 8) {
+      return 1;
+    }
+  }
+
+  return 0;
 }
 
 bool GSM::shutdown()

--- a/src/GSMServer.cpp
+++ b/src/GSMServer.cpp
@@ -240,13 +240,17 @@ void GSMServer::handleUrc(const String& urc)
   } else if (urc.startsWith("+UUSOCL: ")) {
     int socket = urc.charAt(urc.length() - 1) - '0';
 
-    for (int i = 0; i < MAX_CHILD_SOCKETS; i++) {
-      if (_childSockets[i].socket == socket) {
-        _childSockets[i].socket = -1;
-        _childSockets[i].accepted = false;
-        _childSockets[i].available = 0;
+    if (socket == _socket) {
+      _socket = -1;
+    } else {
+      for (int i = 0; i < MAX_CHILD_SOCKETS; i++) {
+        if (_childSockets[i].socket == socket) {
+          _childSockets[i].socket = -1;
+          _childSockets[i].accepted = false;
+          _childSockets[i].available = 0;
 
-        break;
+          break;
+        }
       }
     }
   } else if (urc.startsWith("+UUSORD: ")) {

--- a/src/GSMUdp.cpp
+++ b/src/GSMUdp.cpp
@@ -76,6 +76,10 @@ void GSMUDP::stop()
 
 int GSMUDP::beginPacket(IPAddress ip, uint16_t port)
 {
+  if (_socket < 0) {
+    return 0;
+  }
+
   _txIp = ip;
   _txHost = NULL;
   _txPort = port;
@@ -86,6 +90,10 @@ int GSMUDP::beginPacket(IPAddress ip, uint16_t port)
 
 int GSMUDP::beginPacket(const char *host, uint16_t port)
 {
+  if (_socket < 0) {
+    return 0;
+  }
+  
   _txIp = (uint32_t)0;
   _txHost = host;
   _txPort = port;
@@ -154,6 +162,10 @@ size_t GSMUDP::write(uint8_t b)
 
 size_t GSMUDP::write(const uint8_t *buffer, size_t size)
 {
+  if (_socket < 0) {
+    return 0;
+  }
+
   size_t spaceAvailable = sizeof(_txBuffer) - _txSize;
 
   if (size > spaceAvailable) {
@@ -169,6 +181,10 @@ size_t GSMUDP::write(const uint8_t *buffer, size_t size)
 int GSMUDP::parsePacket()
 {
   MODEM.poll();
+
+  if (_socket < 0) {
+    return 0;
+  }
 
   if (!_packetReceived) {
     return 0;
@@ -239,6 +255,10 @@ int GSMUDP::parsePacket()
 
 int GSMUDP::available()
 {
+  if (_socket < 0) {
+    return 0;
+  }
+
   return (_rxIndex - _rxSize);
 }
 
@@ -298,6 +318,15 @@ void GSMUDP::handleUrc(const String& urc)
 
     if (socket == _socket) {
       _packetReceived = true;
+    }
+  } else if (urc.startsWith("+UUSOCL: ")) {
+    int socket = urc.charAt(urc.length() - 1) - '0';
+
+    if (socket == _socket) {
+      // this socket closed
+      _socket = -1;
+      _rxIndex = 0;
+      _rxSize = 0;
     }
   }
 }


### PR DESCRIPTION
This is a proposal for issue #15. Changes include:

* correcting `GSM::isAccessAlive()` to report current registration status
* adding timeout for `GPRS::ping(...)`
* new `GPRS::status` API to return the current status `IDLE` or `GPRS_READY`. The status is updated on `GPRS::attachGPRS(...)`, `GPRS::detachGPRS(...)` or when a `+UUPSDD` is received.

It's still not ready, as it can't detect the scenario where you manually disconnect the antenna and the board loses signal.

cc/ @alvarolb @FrancMunoz @w3p706