### PR TITLE
Replace boolean type with bool in examples

### DIFF
--- a/examples/GPRSPing/GPRSPing.ino
+++ b/examples/GPRSPing/GPRSPing.ino
@@ -39,7 +39,7 @@ void setup() {
 
  Serial.println("Starting Arduino GPRS ping.");
  // connection state
- boolean connected = false;
+ bool connected = false;
 
  // After starting the modem with GSM.begin()
  // attach the shield to the GPRS network with the APN, login and password

--- a/examples/GPRSUdpNtpClient/GPRSUdpNtpClient.ino
+++ b/examples/GPRSUdpNtpClient/GPRSUdpNtpClient.ino
@@ -56,7 +56,7 @@ void setup()
 
   Serial.println("Starting Arduino GPRS NTP client.");
   // connection state
-  boolean connected = false;
+  bool connected = false;
 
   // After starting the modem with GSM.begin()
   // attach the shield to the GPRS network with the APN, login and password

--- a/examples/GsmLocation/GsmLocation.ino
+++ b/examples/GsmLocation/GsmLocation.ino
@@ -40,7 +40,7 @@ void setup() {
 
   Serial.println("Starting GSM location.");
   // connection state
-  boolean connected = false;
+  bool connected = false;
 
   // After starting the modem with GSM.begin()
   // attach the shield to the GPRS network with the APN, login and password

--- a/examples/GsmSSLWebClient/GsmSSLWebClient.ino
+++ b/examples/GsmSSLWebClient/GsmSSLWebClient.ino
@@ -45,7 +45,7 @@ void setup() {
 
   Serial.println("Starting Arduino web client.");
   // connection state
-  boolean connected = false;
+  bool connected = false;
 
   // After starting the modem with GSM.begin()
   // attach the shield to the GPRS network with the APN, login and password

--- a/examples/GsmWebClient/GsmWebClient.ino
+++ b/examples/GsmWebClient/GsmWebClient.ino
@@ -45,7 +45,7 @@ void setup() {
 
   Serial.println("Starting Arduino web client.");
   // connection state
-  boolean connected = false;
+  bool connected = false;
 
   // After starting the modem with GSM.begin()
   // attach the shield to the GPRS network with the APN, login and password

--- a/examples/GsmWebServer/GsmWebServer.ino
+++ b/examples/GsmWebServer/GsmWebServer.ino
@@ -42,7 +42,7 @@ void setup() {
   }
 
   // connection state
-  boolean connected = false;
+  bool connected = false;
 
   // Start GSM shield
   // If your SIM has PIN, pass it as a parameter of begin() in quotes

--- a/examples/MakeVoiceCall/MakeVoiceCall.ino
+++ b/examples/MakeVoiceCall/MakeVoiceCall.ino
@@ -43,7 +43,7 @@ void setup() {
   Serial.println("Make Voice Call");
 
   // connection state
-  boolean connected = false;
+  bool connected = false;
 
   // Start GSM shield
   // If your SIM has PIN, pass it as a parameter of begin() in quotes

--- a/examples/ReceiveSMS/ReceiveSMS.ino
+++ b/examples/ReceiveSMS/ReceiveSMS.ino
@@ -38,7 +38,7 @@ void setup() {
   Serial.println("SMS Messages Receiver");
 
   // connection state
-  boolean connected = false;
+  bool connected = false;
 
   // Start GSM connection
   while (!connected) {

--- a/examples/ReceiveVoiceCall/ReceiveVoiceCall.ino
+++ b/examples/ReceiveVoiceCall/ReceiveVoiceCall.ino
@@ -38,7 +38,7 @@ void setup() {
   Serial.println("Receive Voice Call");
 
   // connection state
-  boolean connected = false;
+  bool connected = false;
 
   // Start GSM shield
   // If your SIM has PIN, pass it as a parameter of begin() in quotes

--- a/examples/SendSMS/SendSMS.ino
+++ b/examples/SendSMS/SendSMS.ino
@@ -39,7 +39,7 @@ void setup() {
   Serial.println("SMS Messages Sender");
 
   // connection state
-  boolean connected = false;
+  bool connected = false;
 
   // Start GSM shield
   // If your SIM has PIN, pass it as a parameter of begin() in quotes

--- a/examples/Tools/BandManagement/BandManagement.ino
+++ b/examples/Tools/BandManagement/BandManagement.ino
@@ -54,7 +54,7 @@ void loop() {
   Serial.print("\nConfiguring band ");
   Serial.println(newBandName);
   // Change the band
-  boolean operationSuccess;
+  bool operationSuccess;
   operationSuccess = band.setBand(newBandName);
   // Tell the user if the operation was OK
   if (operationSuccess) {

--- a/examples/Tools/GsmScanNetworks/GsmScanNetworks.ino
+++ b/examples/Tools/GsmScanNetworks/GsmScanNetworks.ino
@@ -48,7 +48,7 @@ void setup() {
   scannerNetworks.begin();
 
   // connection state
-  boolean connected = false;
+  bool connected = false;
 
   // Start GSM shield
   // If your SIM has PIN, pass it as a parameter of begin() in quotes

--- a/examples/Tools/PinManagement/PinManagement.ino
+++ b/examples/Tools/PinManagement/PinManagement.ino
@@ -22,7 +22,7 @@ GSMPIN PINManager;
 String user_input = "";
 
 // authenticated with PIN code
-boolean auth = false;
+bool auth = false;
 
 // serial monitor result messages
 String oktext = "OK";

--- a/examples/Tools/TestGPRS/TestGPRS.ino
+++ b/examples/Tools/TestGPRS/TestGPRS.ino
@@ -39,7 +39,7 @@ char path[] = "/";
 String response = "";
 
 // use a proxy
-boolean use_proxy = false;
+bool use_proxy = false;
 
 void setup() {
   // initialize serial communications and wait for port to open:
@@ -136,7 +136,7 @@ void loop() {
     }
     Serial.print("Receiving response...");
 
-    boolean test = true;
+    bool test = true;
     while (test) {
       // if there are incoming bytes available
       // from the server, read and check them

--- a/examples/Tools/TestWebServer/TestWebServer.ino
+++ b/examples/Tools/TestWebServer/TestWebServer.ino
@@ -42,7 +42,7 @@ void setup() {
 
   Serial.println("starting,..");
   // connection state
-  boolean connected = false;
+  bool connected = false;
 
   // Start GSM shield
   // If your SIM has PIN, pass it as a parameter of begin() in quotes


### PR DESCRIPTION
Replace boolean type with bool in examples

This is part of a move to encourage use of the standard bool type over Arduino's non-standard boolean type alias.

As approved by cmaglie: https://github.com/arduino/Arduino/issues/6657#issuecomment-355597633