### PR TITLE
Fix GSMClient::write(uint8_t c)

### DIFF
--- a/src/GSMClient.cpp
+++ b/src/GSMClient.cpp
@@ -227,7 +227,7 @@ void GSMClient::beginWrite(bool sync)
 
 size_t GSMClient::write(uint8_t c)
 {
-  return write(&c,1);
+  return write(&c, 1);
 }
 
 size_t GSMClient::write(const uint8_t *buf)

--- a/src/GSMClient.cpp
+++ b/src/GSMClient.cpp
@@ -227,7 +227,7 @@ void GSMClient::beginWrite(bool sync)
 
 size_t GSMClient::write(uint8_t c)
 {
-  return write(&c);
+  return write(&c,1);
 }
 
 size_t GSMClient::write(const uint8_t *buf)


### PR DESCRIPTION
call of the function` size_t GSMClient::write(const uint8_t* buf, size_t size)` instead of `size_t GSMClient::write(const uint8_t* buf)` in `GSMClient::write(uint8_t c)`
