### PR TITLE
[DO NOT MERGE] Add timeout for modem echoing AT command

### DIFF
--- a/src/Modem.h
+++ b/src/Modem.h
@@ -68,6 +68,8 @@ private:
   int _resetPin;
   int _dtrPin;
   bool _lowPowerMode;
+  unsigned int _lastCommandLength;
+  unsigned long _lastCommandSentMillis;
   unsigned long _lastResponseOrUrcMillis;
 
   enum {


### PR DESCRIPTION
As discussed in https://github.com/arduino-libraries/MKRGSM/pull/50#issuecomment-425447301.

Note: this changes the logic not to wait for the `\r\n`, since the modem doesn't echo that until the response is ready as observed by the `AT+UPSDA=0,3` command. Instead now we wait to an `AT` prefix + the command length bytes.