### PR TITLE
Add setTimeout and status() API's

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -27,6 +27,7 @@ begin	KEYWORD2
 shutdown	KEYWORD2
 gatVoiceCallStatus	KEYWORD2
 ready	KEYWORD2
+setTimeout	KEYWORD2
 voiceCall	KEYWORD2
 answerCall	KEYWORD2
 hangCall	KEYWORD2

--- a/src/GPRS.cpp
+++ b/src/GPRS.cpp
@@ -48,7 +48,8 @@ GPRS::GPRS() :
   _apn(NULL),
   _username(NULL),
   _password(NULL),
-  _status(IDLE)
+  _status(IDLE),
+  _timeout(0)
 {
   MODEM.addUrcHandler(this);
 }
@@ -68,7 +69,14 @@ GSM3_NetworkStatus_t GPRS::attachGPRS(const char* apn, const char* user_name, co
   _status = CONNECTING;
 
   if (synchronous) {
+    unsigned long start = millis();
+
     while (ready() == 0) {
+      if (_timeout && !((millis() - start) < _timeout)) {
+        _state = ERROR;
+        break;
+      }
+
       delay(100);
     }
   } else {
@@ -310,6 +318,11 @@ IPAddress GPRS::getIPAddress()
   }
 
   return IPAddress(0, 0, 0, 0);
+}
+
+void GPRS::setTimeout(unsigned long timeout)
+{
+  _timeout = timeout;
 }
 
 int GPRS::hostByName(const char* hostname, IPAddress& result)

--- a/src/GPRS.h
+++ b/src/GPRS.h
@@ -80,6 +80,7 @@ public:
    */
   IPAddress getIPAddress();
 
+  void setTimeout(unsigned long timeout);
 
   int hostByName(const char* hostname, IPAddress& result);
   int hostByName(const String &hostname, IPAddress& result) { return hostByName(hostname.c_str(), result); }
@@ -100,6 +101,7 @@ private:
   GSM3_NetworkStatus_t _status;
   String _response;
   int _pingResult;
+  unsigned long _timeout;
 };
 
 #endif

--- a/src/GSM.cpp
+++ b/src/GSM.cpp
@@ -46,7 +46,8 @@ enum {
 GSM::GSM(bool debug) :
   _state(ERROR),
   _readyState(0),
-  _pin(NULL)
+  _pin(NULL),
+  _timeout(0)
 {
   if (debug) {
     MODEM.debug();
@@ -63,7 +64,14 @@ GSM3_NetworkStatus_t GSM::begin(const char* pin, bool restart, bool synchronous)
     _readyState = READY_STATE_CHECK_SIM;
 
     if (synchronous) {
+      unsigned long start = millis();
+
       while (ready() == 0) {
+        if (_timeout && !((millis() - start) < _timeout)) {
+          _state = ERROR;
+          break;
+        }
+
         delay(100);
       }
     } else {
@@ -313,6 +321,11 @@ int GSM::ready()
   }
 
   return ready;
+}
+
+void GSM::setTimeout(unsigned long timeout)
+{
+  _timeout = timeout;
 }
 
 unsigned long GSM::getTime()

--- a/src/GSM.cpp
+++ b/src/GSM.cpp
@@ -385,3 +385,8 @@ int GSM::noLowPowerMode()
 {
   return MODEM.noLowPowerMode();
 }
+
+GSM3_NetworkStatus_t GSM::status()
+{
+  return _state;
+}

--- a/src/GSM.h
+++ b/src/GSM.h
@@ -66,6 +66,8 @@ public:
     */
   int ready();
 
+  void setTimeout(unsigned long timeout);
+
   unsigned long getTime();
   unsigned long getLocalTime();
 
@@ -77,6 +79,7 @@ private:
   int _readyState;
   const char* _pin;
   String _response;
+  unsigned long _timeout;
 };
 
 #endif

--- a/src/GSM.h
+++ b/src/GSM.h
@@ -74,6 +74,8 @@ public:
   int lowPowerMode();
   int noLowPowerMode();
 
+  GSM3_NetworkStatus_t status();
+
 private:
   GSM3_NetworkStatus_t _state;
   int _readyState;


### PR DESCRIPTION
This adds the following:

* ` GSM::setTimeout(...)` and `GPRS::setTimeout(...) ` API's to set timeout value for `.begin(...)`. The default timeout is 0, which means try forever (current behaviour). As discussed in https://github.com/arduino-libraries/MKRGSM/issues/36
* `GSM::status()` API to retrieve the current state something discussed in https://github.com/arduino-libraries/MKRGSM/pull/37.

cc/ @FrancMunoz @Rocketct

