### PR TITLE
Fix some regressions introduced by the new socket buffer

### DIFF
--- a/src/GSMClient.h
+++ b/src/GSMClient.h
@@ -22,9 +22,7 @@
 
 #include <Client.h>
 
-#include "Modem.h"
-
-class GSMClient : public Client, public ModemUrcHandler {
+class GSMClient : public Client {
 
 public:
 
@@ -127,8 +125,6 @@ public:
   /** Stop client
    */
   void stop();
-
-  virtual void handleUrc(const String& urc);
 
 private:
   int connect();


### PR DESCRIPTION
The last chunk of data received on the socket before it closes was not returned. The URC caused the socket to be in the closed state.

Related to #44.

sketch to test with
```arduino
#include "arduino_secrets.h"

#include "MKRGSM.h"
#include "ArduinoHttpClient.h"
//Secrets below kept in secrets tab (arduino_secrets.h)
const char PINNUMBER[] = SECRET_PINNUMBER;
// APN data
const char GPRS_APN[] = SECRET_GPRS_APN;
const char GPRS_LOGIN[] = SECRET_GPRS_LOGIN;
const char GPRS_PASSWORD[] = SECRET_GPRS_PASSWORD;

GSM gsmAccess(true); // Cellular modem instance
GPRS gprs;     // With TCP/IP based communication enabled
GSMSSLClient gsm; // Accessible by Arduino sketch as a standard Stream class

// Create an HTTP client on top of all this
char server[] = "arduino.cc";
char path[] = "/asciilogo.txt";
int port = 443; // port 80 is the default for HTTP

HttpClient client = HttpClient(gsm, server, port);
String response;
int statusCode = 0;


// Set up serial out and cellular modem

void setup() {
  Serial.begin(9600);
  // connection state
  bool connected = false;
  // After starting the modem with GSM.begin()
  // attach to GPRS network with the APN, login and password
  while (!connected) {
    if ((gsmAccess.begin(PINNUMBER) == GSM_READY) &&
        (gprs.attachGPRS(GPRS_APN, GPRS_LOGIN, GPRS_PASSWORD) == GPRS_READY)) {
      connected = true;
    } else {
      Serial.println("Not connected");
      delay(1000);
    }
  }
}


void loop() {
  
  Serial.println("Making HTTP GET request");
//  client.setHttpResponseTimeout(240 * 1000);
  Serial.println(client.get(path));
  

  // read the status code and body of the response
  statusCode = client.responseStatusCode();
  response = client.responseBody();
  
  Serial.print("Status code: ");
  Serial.println(statusCode);
  Serial.print("Response: ");
  Serial.println(response);

  client.stop();
  
  delay(5000);
  
}
```