### PR TITLE
Reset GSMClient state at the beginning of stop() method

### DIFF
--- a/src/GSMClient.cpp
+++ b/src/GSMClient.cpp
@@ -421,6 +421,8 @@ void GSMClient::flush()
 
 void GSMClient::stop()
 {
+  _state = CLIENT_STATE_IDLE;
+
   if (_socket < 0) {
     return;
   }
@@ -429,7 +431,6 @@ void GSMClient::stop()
   MODEM.waitForResponse(10000);
 
   GSMSocketBuffer.close(_socket);
-  _state = CLIENT_STATE_IDLE;
   _socket = -1;
   _connected = false;
 }


### PR DESCRIPTION
Set GSMClient state to CLIENT_STATE_IDLE at the beginning of the stop() method so that the state is reset even if the _socket value is -1.  This is necessary because the state can be left in CLIENT_STATE_WAIT_CREATE_SOCKET_RESPONSE state with _socket = -1 if the AT+USOCR= command hangs.