### PR TITLE
Add GSM status check

### DIFF
--- a/src/GSM.cpp
+++ b/src/GSM.cpp
@@ -100,15 +100,13 @@ int GSM::isAccessAlive()
 
 bool GSM::shutdown()
 {
-  MODEM.send("AT+CPWROFF");
-
-  if (MODEM.waitForResponse(40000) == 1) {
-    MODEM.end();
-    _state = GSM_OFF;
-    return true;
+  if (_state == READY_STATE_DONE) {
+    MODEM.send("AT+CPWROFF");
+    MODEM.waitForResponse(40000);
   }
-
-  return false;
+  MODEM.end();
+  _state = GSM_OFF;
+  return true;
 }
 
 bool GSM::secureShutdown()


### PR DESCRIPTION
Added GSM status check in shutdown() function to avoid freeze made by a double calling of GSM::suhutdown() API

cc/ @sandeepmistry 