### PR TITLE
Fix one char SMS receiving

### DIFF
--- a/src/GSM_SMS.cpp
+++ b/src/GSM_SMS.cpp
@@ -149,7 +149,7 @@ int GSM_SMS::available()
       _smsDataEndIndex = _incomingBuffer.length() - 1;
     }
 
-    return (_smsDataEndIndex - _smsDataIndex);
+    return (_smsDataEndIndex - _smsDataIndex) + 1;
   } else {
     _incomingBuffer = "";
   }


### PR DESCRIPTION
Added a ```+1``` in the available API's return to avoid that SMS with only 1 char are discarded

Resolve https://github.com/arduino-libraries/MKRGSM/issues/63#event-1977412413

cc/ @sandeepmistry just tested ready to merge