### PR TITLE
Fix GSMClient::write for write lengths of > 256

### DIFF
--- a/src/GSMClient.cpp
+++ b/src/GSMClient.cpp
@@ -283,6 +283,7 @@ size_t GSMClient::write(const uint8_t* buf, size_t size)
   size_t written = 0;
   String command;
 
+  command.reserve(19 + (size > 256 ? 256 : size) * 2);
 
   while (size) {
     size_t chunkSize = size;
@@ -291,9 +292,7 @@ size_t GSMClient::write(const uint8_t* buf, size_t size)
       chunkSize = 256;
     }
 
-    command.reserve(19 + chunkSize * 2);
-
-    command += "AT+USOWR=";
+    command = "AT+USOWR=";
     command += _socket;
     command += ",";
     command += chunkSize;


### PR DESCRIPTION
As suggested by @winijenh in #75.