### PR TITLE
Method to retrieve SIM's ICCID

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -39,6 +39,7 @@ attachGPRS	KEYWORD2
 begnWrite	KEYWORD2
 endWrite	KEYWORD2
 getIMEI	KEYWORD2
+getICCID KEYWORD2
 getCurrentCarrier	KEYWORD2
 getSignalStrength	KEYWORD2
 readNetworks	KEYWORD2

--- a/src/GSMModem.cpp
+++ b/src/GSMModem.cpp
@@ -45,3 +45,15 @@ String GSMModem::getIMEI()
 
   return imei;
 }
+
+String GSMModem::getICCID()
+{
+  String iccid;
+
+  iccid.reserve(20);
+
+  MODEM.send("AT+CCID");
+  MODEM.waitForResponse(120, &iccid);
+
+  return iccid;
+}

--- a/src/GSMModem.h
+++ b/src/GSMModem.h
@@ -37,6 +37,10 @@ public:
       @return modem IMEI number
    */
   String getIMEI();
+
+  /** Obtain SIM card ICCID (command AT)
+      @return SIM ICCID number
+   */
   String getICCID();
 };
 

--- a/src/GSMModem.h
+++ b/src/GSMModem.h
@@ -37,6 +37,7 @@ public:
       @return modem IMEI number
    */
   String getIMEI();
+  String getICCID();
 };
 
 #endif


### PR DESCRIPTION
- implemented `getICCID()` method to retrieve SIM ICCID number as a String