### PR TITLE
Add setBaudRate and setDebugStream to Modem class

### DIFF
--- a/src/Modem.cpp
+++ b/src/Modem.cpp
@@ -33,7 +33,8 @@ ModemClass::ModemClass(Uart& uart, unsigned long baud, int resetPin, int dtrPin)
   _lastResponseOrUrcMillis(0),
   _atCommandState(AT_COMMAND_IDLE),
   _ready(1),
-  _responseDataStorage(NULL)
+  _responseDataStorage(NULL),
+  _debugStream(&Serial)
 {
   _buffer.reserve(64);
 }
@@ -246,8 +247,8 @@ void ModemClass::poll()
   while (_uart->available()) {
     char c = _uart->read();
 
-    if (_debug) {
-      Serial.write(c);
+    if (_debug && _debugStream) {
+      _debugStream->write(c);
     }
 
     _buffer += c;
@@ -350,6 +351,11 @@ void ModemClass::removeUrcHandler(ModemUrcHandler* handler)
 void ModemClass::setBaudRate(unsigned long baud)
 {
   _baud = baud;
+}
+
+void ModemClass::setDebugStream(Stream& stream)
+{
+  _debugStream = &stream;
 }
 
 ModemClass MODEM(SerialGSM, 921600, GSM_RESETN, GSM_DTR);

--- a/src/Modem.cpp
+++ b/src/Modem.cpp
@@ -347,4 +347,9 @@ void ModemClass::removeUrcHandler(ModemUrcHandler* handler)
   }
 }
 
+void ModemClass::setBaudRate(unsigned long baud)
+{
+  _baud = baud;
+}
+
 ModemClass MODEM(SerialGSM, 921600, GSM_RESETN, GSM_DTR);

--- a/src/Modem.cpp
+++ b/src/Modem.cpp
@@ -23,6 +23,7 @@
 
 bool ModemClass::_debug = false;
 ModemUrcHandler* ModemClass::_urcHandlers[MAX_URC_HANDLERS] = { NULL };
+Print* ModemClass::_debugPrint = &Serial;
 
 ModemClass::ModemClass(Uart& uart, unsigned long baud, int resetPin, int dtrPin) :
   _uart(&uart),
@@ -33,8 +34,7 @@ ModemClass::ModemClass(Uart& uart, unsigned long baud, int resetPin, int dtrPin)
   _lastResponseOrUrcMillis(0),
   _atCommandState(AT_COMMAND_IDLE),
   _ready(1),
-  _responseDataStorage(NULL),
-  _debugStream(&Serial)
+  _responseDataStorage(NULL)
 {
   _buffer.reserve(64);
 }
@@ -247,8 +247,8 @@ void ModemClass::poll()
   while (_uart->available()) {
     char c = _uart->read();
 
-    if (_debug && _debugStream) {
-      _debugStream->write(c);
+    if (_debug && _debugPrint) {
+      _debugPrint->write(c);
     }
 
     _buffer += c;
@@ -353,9 +353,9 @@ void ModemClass::setBaudRate(unsigned long baud)
   _baud = baud;
 }
 
-void ModemClass::setDebugStream(Stream& stream)
+void ModemClass::setDebugPrint(Print& print)
 {
-  _debugStream = &stream;
+  _debugPrint = &print;
 }
 
 ModemClass MODEM(SerialGSM, 921600, GSM_RESETN, GSM_DTR);

--- a/src/Modem.cpp
+++ b/src/Modem.cpp
@@ -21,9 +21,7 @@
 
 #define MODEM_MIN_RESPONSE_OR_URC_WAIT_TIME_MS 20
 
-bool ModemClass::_debug = false;
 ModemUrcHandler* ModemClass::_urcHandlers[MAX_URC_HANDLERS] = { NULL };
-Print* ModemClass::_debugPrint = &Serial;
 
 ModemClass::ModemClass(Uart& uart, unsigned long baud, int resetPin, int dtrPin) :
   _uart(&uart),
@@ -34,7 +32,8 @@ ModemClass::ModemClass(Uart& uart, unsigned long baud, int resetPin, int dtrPin)
   _lastResponseOrUrcMillis(0),
   _atCommandState(AT_COMMAND_IDLE),
   _ready(1),
-  _responseDataStorage(NULL)
+  _responseDataStorage(NULL),
+  _debugPrint(NULL)
 {
   _buffer.reserve(64);
 }
@@ -102,12 +101,17 @@ void ModemClass::end()
 
 void ModemClass::debug()
 {
-  _debug = true;
+  debug(Serial);
+}
+
+void ModemClass::debug(Print& p)
+{
+  _debugPrint = &p;
 }
 
 void ModemClass::noDebug()
 {
-  _debug = false;
+  _debugPrint = NULL;
 }
 
 int ModemClass::autosense(unsigned int timeout)
@@ -247,7 +251,7 @@ void ModemClass::poll()
   while (_uart->available()) {
     char c = _uart->read();
 
-    if (_debug && _debugPrint) {
+    if (_debugPrint) {
       _debugPrint->write(c);
     }
 
@@ -351,11 +355,6 @@ void ModemClass::removeUrcHandler(ModemUrcHandler* handler)
 void ModemClass::setBaudRate(unsigned long baud)
 {
   _baud = baud;
-}
-
-void ModemClass::setDebugPrint(Print& print)
-{
-  _debugPrint = &print;
 }
 
 ModemClass MODEM(SerialGSM, 921600, GSM_RESETN, GSM_DTR);

--- a/src/Modem.h
+++ b/src/Modem.h
@@ -65,7 +65,7 @@ public:
   void removeUrcHandler(ModemUrcHandler* handler);
 
   void setBaudRate(unsigned long baud);
-  void setDebugStream(Stream& debugStream);
+  void setDebugPrint(Print& debugPrint);
 
 private:
   Uart* _uart;
@@ -87,7 +87,7 @@ private:
   static bool _debug;
   static ModemUrcHandler* _urcHandlers[MAX_URC_HANDLERS];
 
-  Stream* _debugStream;
+  static Print* _debugPrint;
 };
 
 extern ModemClass MODEM;

--- a/src/Modem.h
+++ b/src/Modem.h
@@ -65,6 +65,7 @@ public:
   void removeUrcHandler(ModemUrcHandler* handler);
 
   void setBaudRate(unsigned long baud);
+  void setDebugStream(Stream& debugStream);
 
 private:
   Uart* _uart;
@@ -85,6 +86,8 @@ private:
   #define MAX_URC_HANDLERS 10 // 7 sockets + GPRS + GSMLocation + GSMVoiceCall
   static bool _debug;
   static ModemUrcHandler* _urcHandlers[MAX_URC_HANDLERS];
+
+  Stream* _debugStream;
 };
 
 extern ModemClass MODEM;

--- a/src/Modem.h
+++ b/src/Modem.h
@@ -64,6 +64,8 @@ public:
   void addUrcHandler(ModemUrcHandler* handler);
   void removeUrcHandler(ModemUrcHandler* handler);
 
+  void setBaudRate(unsigned long baud);
+
 private:
   Uart* _uart;
   unsigned long _baud;

--- a/src/Modem.h
+++ b/src/Modem.h
@@ -38,6 +38,7 @@ public:
   void end();
 
   void debug();
+  void debug(Print& p);
   void noDebug();
 
   int autosense(unsigned int timeout = 10000);
@@ -65,7 +66,6 @@ public:
   void removeUrcHandler(ModemUrcHandler* handler);
 
   void setBaudRate(unsigned long baud);
-  void setDebugPrint(Print& debugPrint);
 
 private:
   Uart* _uart;
@@ -82,12 +82,10 @@ private:
   int _ready;
   String _buffer;
   String* _responseDataStorage;
+  Print* _debugPrint;
 
   #define MAX_URC_HANDLERS 10 // 7 sockets + GPRS + GSMLocation + GSMVoiceCall
-  static bool _debug;
   static ModemUrcHandler* _urcHandlers[MAX_URC_HANDLERS];
-
-  static Print* _debugPrint;
 };
 
 extern ModemClass MODEM;


### PR DESCRIPTION
Sometimes it is useful to slow down modem baud rate and send debug info somewhere else. Additions do not change default behaviour (baud rate 921600 and Serial as debug output) 