### PR TITLE
Add timeouts to GSMClient

### DIFF
--- a/src/GSMClient.h
+++ b/src/GSMClient.h
@@ -128,6 +128,14 @@ public:
    */
   void stop();
 
+  /** Set timeout for connecting
+   */
+  void setConnectTimeout(unsigned long timeout);
+
+  /** Set timeout for socket operations
+   */
+  void setSocketTimeout(unsigned long timeout);
+
   virtual void handleUrc(const String& urc);
 
 private:
@@ -145,6 +153,9 @@ private:
 
   bool _writeSync;
   String _response;
+
+  unsigned long _connectTimeout;
+  unsigned long _socketTimeout;
 };
 
 #endif


### PR DESCRIPTION
Timeouts on connect and write prevents sketch lockups due to poorly powered modem.