### PR TITLE
Add getters and setters to GPRS, GSM, GSMClient for custom inherited classes

### DIFF
--- a/src/GPRS.cpp
+++ b/src/GPRS.cpp
@@ -320,6 +320,10 @@ IPAddress GPRS::getIPAddress()
   return IPAddress(0, 0, 0, 0);
 }
 
+unsigned long GPRS::timeout() {
+  return _timeout;
+}
+
 void GPRS::setTimeout(unsigned long timeout)
 {
   _timeout = timeout;
@@ -396,6 +400,16 @@ GSM3_NetworkStatus_t GPRS::status()
   MODEM.poll();
 
   return _status;
+}
+
+int GPRS::state()
+{
+  return _state;
+}
+
+void GPRS::setState(int state) 
+{
+  _state = state;
 }
 
 void GPRS::handleUrc(const String& urc)

--- a/src/GPRS.cpp
+++ b/src/GPRS.cpp
@@ -320,7 +320,8 @@ IPAddress GPRS::getIPAddress()
   return IPAddress(0, 0, 0, 0);
 }
 
-unsigned long GPRS::timeout() {
+unsigned long GPRS::timeout()
+{
   return _timeout;
 }
 

--- a/src/GPRS.h
+++ b/src/GPRS.h
@@ -80,6 +80,7 @@ public:
    */
   IPAddress getIPAddress();
 
+  unsigned long timeout();
   void setTimeout(unsigned long timeout);
 
   int hostByName(const char* hostname, IPAddress& result);
@@ -90,6 +91,8 @@ public:
   int ping(IPAddress ip, uint8_t ttl = 128);
 
   GSM3_NetworkStatus_t status();
+  int state();
+  void setState(int state);
 
   void handleUrc(const String& urc);
 

--- a/src/GSM.cpp
+++ b/src/GSM.cpp
@@ -321,7 +321,8 @@ int GSM::ready()
   return ready;
 }
 
-unsigned long GSM::timeout() {
+unsigned long GSM::timeout()
+{
   return _timeout;
 }
 

--- a/src/GSM.cpp
+++ b/src/GSM.cpp
@@ -321,6 +321,10 @@ int GSM::ready()
   return ready;
 }
 
+unsigned long GSM::timeout() {
+  return _timeout;
+}
+
 void GSM::setTimeout(unsigned long timeout)
 {
   _timeout = timeout;
@@ -387,4 +391,14 @@ int GSM::noLowPowerMode()
 GSM3_NetworkStatus_t GSM::status()
 {
   return _state;
+}
+
+GSM3_NetworkStatus_t GSM::state()
+{
+  return _state;
+}
+
+void GSM::setState(GSM3_NetworkStatus_t state) 
+{
+  _state = state;
 }

--- a/src/GSM.h
+++ b/src/GSM.h
@@ -66,6 +66,7 @@ public:
     */
   int ready();
 
+  unsigned long timeout();
   void setTimeout(unsigned long timeout);
 
   unsigned long getTime();
@@ -75,6 +76,8 @@ public:
   int noLowPowerMode();
 
   GSM3_NetworkStatus_t status();
+  GSM3_NetworkStatus_t state();
+  void setState(GSM3_NetworkStatus_t state);
 
 private:
   GSM3_NetworkStatus_t _state;

--- a/src/GSMClient.cpp
+++ b/src/GSMClient.cpp
@@ -23,20 +23,6 @@
 
 #include "GSMClient.h"
 
-enum {
-  CLIENT_STATE_IDLE,
-  CLIENT_STATE_CREATE_SOCKET,
-  CLIENT_STATE_WAIT_CREATE_SOCKET_RESPONSE,
-  CLIENT_STATE_ENABLE_SSL,
-  CLIENT_STATE_WAIT_ENABLE_SSL_RESPONSE,
-  CLIENT_STATE_MANAGE_SSL_PROFILE,
-  CLIENT_STATE_WAIT_MANAGE_SSL_PROFILE_RESPONSE,
-  CLIENT_STATE_CONNECT,
-  CLIENT_STATE_WAIT_CONNECT_RESPONSE,
-  CLIENT_STATE_CLOSE_SOCKET,
-  CLIENT_STATE_WAIT_CLOSE_SOCKET
-};
-
 GSMClient::GSMClient(bool synch) :
   GSMClient(-1, synch)
 {
@@ -445,4 +431,20 @@ void GSMClient::handleUrc(const String& urc)
       }
     }
   }
+}
+
+int GSMClient::state() {
+	return _state;
+}
+
+void GSMClient::setState(int state) {
+	_state = state;
+}
+
+int GSMClient::socket() {
+	return _socket;
+}
+
+const char* GSMClient::host() {
+	return _host;
 }

--- a/src/GSMClient.cpp
+++ b/src/GSMClient.cpp
@@ -433,18 +433,22 @@ void GSMClient::handleUrc(const String& urc)
   }
 }
 
-int GSMClient::state() {
-	return _state;
+int GSMClient::state()
+{
+  return _state;
 }
 
-void GSMClient::setState(int state) {
-	_state = state;
+void GSMClient::setState(int state)
+{
+  _state = state;
 }
 
-int GSMClient::socket() {
-	return _socket;
+int GSMClient::socket()
+{
+  return _socket;
 }
 
-const char* GSMClient::host() {
-	return _host;
+const char* GSMClient::host()
+{
+  return _host;
 }

--- a/src/GSMClient.h
+++ b/src/GSMClient.h
@@ -24,6 +24,20 @@
 
 #include <Client.h>
 
+enum {
+  CLIENT_STATE_IDLE,
+  CLIENT_STATE_CREATE_SOCKET,
+  CLIENT_STATE_WAIT_CREATE_SOCKET_RESPONSE,
+  CLIENT_STATE_ENABLE_SSL,
+  CLIENT_STATE_WAIT_ENABLE_SSL_RESPONSE,
+  CLIENT_STATE_MANAGE_SSL_PROFILE,
+  CLIENT_STATE_WAIT_MANAGE_SSL_PROFILE_RESPONSE,
+  CLIENT_STATE_CONNECT,
+  CLIENT_STATE_WAIT_CONNECT_RESPONSE,
+  CLIENT_STATE_CLOSE_SOCKET,
+  CLIENT_STATE_WAIT_CLOSE_SOCKET
+};
+
 class GSMClient : public Client, public ModemUrcHandler {
 
 public:
@@ -129,6 +143,11 @@ public:
   void stop();
 
   virtual void handleUrc(const String& urc);
+
+  int state();
+  void setState(int state);
+  int socket();
+  const char* host();
 
 private:
   int connect();


### PR DESCRIPTION
As mentioned in #84, when we need to create async version of these classes and keep the same logic as the original version, we need to access several internal variables.  Therefore, we need getter and setter pairs for them.

I successfully create async version of these three classes (in my own library) with these modified sync version.  New getters and setters has absolutely no impact to existing library/existing Arduino project, because they don't modify any existing functions.