### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -39,7 +39,7 @@ attachGPRS	KEYWORD2
 begnWrite	KEYWORD2
 endWrite	KEYWORD2
 getIMEI	KEYWORD2
-getICCID KEYWORD2
+getICCID	KEYWORD2
 getCurrentCarrier	KEYWORD2
 getSignalStrength	KEYWORD2
 readNetworks	KEYWORD2
@@ -51,8 +51,8 @@ switchPIN	KEYWORD2
 checkReg	KEYWORD2
 getPINUsed	KEYWORD2
 setPINUsed	KEYWORD2
-getBand		KEYWORD2
-setBand		KEYWORD2
+getBand	KEYWORD2
+setBand	KEYWORD2
 getvoiceCallStatus	KEYWORD2
 hostByName	KEYWORD2
 ping	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty `KEYWORD_TOKENTYPE` field causes the default `editor.function.style` highlighting  to be used (as with `KEYWORD2`, `KEYWORD3`). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special highlighting.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords