### PR TITLE
fix compiler complaint about `strptime`

### DIFF
--- a/src/GSM.cpp
+++ b/src/GSM.cpp
@@ -17,6 +17,7 @@
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#define _XOPEN_SOURCE
 #include <time.h>
 
 #include "Modem.h"


### PR DESCRIPTION
from @facchinm :
compilation fails due to
`error: 'strptime' was not declared in this scope` 
which is in fact fixed by `_XOPEN_SOURCE patch`