### PR TITLE
Handle SMS responses 

### DIFF
--- a/src/Modem.cpp
+++ b/src/Modem.cpp
@@ -302,10 +302,7 @@ void ModemClass::poll()
             }
           }
           
-          int responseResultIndex;
-
-          responseResultIndex = _buffer.lastIndexOf("OK\r\n");
-
+          int responseResultIndex = _buffer.lastIndexOf("OK\r\n");
           if (responseResultIndex >= endOfResponse) {
             _ready = 1;
           } else {

--- a/src/Modem.cpp
+++ b/src/Modem.cpp
@@ -302,16 +302,19 @@ void ModemClass::poll()
             }
           }
           
-          int responseResultIndex = _buffer.lastIndexOf("OK\r\n",endOfResponse);
-          if (responseResultIndex != -1) {
+          int responseResultIndex;
+
+          responseResultIndex = _buffer.lastIndexOf("OK\r\n");
+
+          if (responseResultIndex >= endOfResponse) {
             _ready = 1;
           } else {
-            responseResultIndex = _buffer.lastIndexOf("ERROR\r\n",endOfResponse);
-            if (responseResultIndex != -1) {
+            responseResultIndex = _buffer.lastIndexOf("ERROR\r\n");
+            if (responseResultIndex >= endOfResponse) {
               _ready = 2;
             } else {
-              responseResultIndex = _buffer.lastIndexOf("NO CARRIER\r\n",endOfResponse);
-              if (responseResultIndex != -1) {
+              responseResultIndex = _buffer.lastIndexOf("NO CARRIER\r\n");
+              if (responseResultIndex >= endOfResponse) {
                 _ready = 3;
               }
             }

--- a/src/Modem.cpp
+++ b/src/Modem.cpp
@@ -285,9 +285,9 @@ void ModemClass::poll()
 
       case AT_RECEIVING_RESPONSE: {
         if (c == '\n') {
-          int endOfResponse = 0;
           _lastResponseOrUrcMillis = millis();
 
+          int endOfResponse = 0;
           if (_buffer.startsWith("+CMGL: ")) {
             // SMS responses can contain "OK\r\n"
             for(int nextSMS = 0; nextSMS != -1; nextSMS = _buffer.indexOf("+CMGL: ",endOfResponse)) {

--- a/src/Modem.cpp
+++ b/src/Modem.cpp
@@ -247,7 +247,7 @@ int ModemClass::ready()
 }
 
 void ModemClass::poll()
-{  
+{
   while (_uart->available()) {
     char c = _uart->read();
 

--- a/src/Modem.h
+++ b/src/Modem.h
@@ -77,7 +77,8 @@ private:
 
   enum {
     AT_COMMAND_IDLE,
-    AT_RECEIVING_RESPONSE
+    AT_RECEIVING_RESPONSE,
+    AT_RECEIVING_END_RESPONSE
   } _atCommandState;
   int _ready;
   String _buffer;

--- a/src/Modem.h
+++ b/src/Modem.h
@@ -77,8 +77,7 @@ private:
 
   enum {
     AT_COMMAND_IDLE,
-    AT_RECEIVING_RESPONSE,
-    AT_RECEIVING_END_RESPONSE
+    AT_RECEIVING_RESPONSE
   } _atCommandState;
   int _ready;
   String _buffer;


### PR DESCRIPTION
Hi, the current code will mis-interpret an SMS response for any SMS with the content "OK".

In this case the AT command response will contain "+CMGL: ...\r\nOK\r\n" which will be caught in MODEM::poll() during the readout of the response, and break the interpreter. 

The pull request contains special handling of "+CMGL:" responses.

I tried to make the change as small as possible, and with as small runtime overhead as possible. It checks if the response contains an SMS response once, and if not, continues with the old code. 