### PR TITLE
Empty FileUtils::read return variables before use

### DIFF
--- a/src/GSMFileUtils.cpp
+++ b/src/GSMFileUtils.cpp
@@ -147,6 +147,7 @@ uint32_t GSMFileUtils::readFile(const String filename, String* content)
     skip += 3;
 
     String* _data = content;
+    (*_data) = "";
     (*_data).reserve(size);
 
     for (auto i = 0; i < size; i++) {
@@ -195,6 +196,8 @@ uint32_t GSMFileUtils::readFile(const String filename, uint8_t* content)
     String sizePart = _content.substring(0, commaIndex);
     uint32_t size = sizePart.toInt() / 2;
     skip += 3;
+
+    memset(content, 0, size);
 
     for (auto i = 0; i < size; i++) {
         byte n1 = response[skip + i * 2];

--- a/src/GSMFileUtils.h
+++ b/src/GSMFileUtils.h
@@ -15,7 +15,9 @@ public:
     uint32_t listFile(const String filename) const;
 
     uint32_t downloadFile(const String filename, const char buf[], const uint32_t size, const bool append);
+    uint32_t downloadFile(const String filename, const uint8_t buf[], const uint32_t size, const bool append) {return downloadFile(filename, reinterpret_cast<const char *>(&buf), size, false); };
     uint32_t downloadFile(const String filename, const char buf[], const uint32_t size) { return downloadFile(filename, buf, size, false); };
+    uint32_t downloadFile(const String filename, const uint8_t buf[], const uint32_t size) { return downloadFile(filename, buf, size, false); };
     uint32_t downloadFile(const String filename, const String& buf) { return downloadFile(filename, buf.c_str(), buf.length(), false); }
 
     uint32_t appendFile(const String filename, const String& buf)                     { return downloadFile(filename, buf.c_str(), buf.length(), true); }


### PR DESCRIPTION
Empty/memset `GSMFileUtils::read()` return parameters before use.

Fixes unwanted appending of contents when reusing return parameters.