### PR TITLE
A little more time for the modem to switch baud rate

### DIFF
--- a/src/Modem.cpp
+++ b/src/Modem.cpp
@@ -68,7 +68,7 @@ int ModemClass::begin(bool restart)
     }
 
     _uart->end();
-    delay(100);
+    delay(200);
     _uart->begin(_baud);
 
     if (!autosense()) {


### PR DESCRIPTION
As mentioned before by others, the delay(100) is confirmed by the ublox datasheet but sometimes the modem hangs during the startup with this value. With a delay(200), it starts.