### PR TITLE
Moving asciilogo.txt to a different domain

### DIFF
--- a/examples/GsmSSLWebClient/GsmSSLWebClient.ino
+++ b/examples/GsmSSLWebClient/GsmSSLWebClient.ino
@@ -32,7 +32,7 @@ GPRS gprs;
 GSM gsmAccess;
 
 // URL, path and port (for example: arduino.cc)
-char server[] = "arduino.cc";
+char server[] = "arduino.tips";
 char path[] = "/asciilogo.txt";
 int port = 443; // port 443 is the default for HTTPS
 

--- a/examples/GsmSSLWebClient/GsmSSLWebClient.ino
+++ b/examples/GsmSSLWebClient/GsmSSLWebClient.ino
@@ -2,7 +2,7 @@
   Web client
 
  This sketch connects to a website using SSL through a MKR GSM 1400 board. Specifically,
- this example downloads the URL "http://www.arduino.cc/asciilogo.txt" and
+ this example downloads the URL "http://arduino.tips/asciilogo.txt" and
  prints it to the Serial Monitor.
 
  Circuit:

--- a/examples/Tools/FileUtilsHttpDownload/FileUtilsHttpDownload.ino
+++ b/examples/Tools/FileUtilsHttpDownload/FileUtilsHttpDownload.ino
@@ -61,7 +61,7 @@ void setup()
 
     printFiles(fileUtils);
 
-    auto server = promptAndReadLine("Please, enter server name:", "arduino.cc");
+    auto server = promptAndReadLine("Please, enter server name:", "arduino.tips");
     auto port = promptAndReadInt("Please, enter server port:", 80);
     auto filename = promptAndReadLine("Please, enter file name:", "asciilogo.txt");
     auto filesize = promptAndReadInt("Please, enter file size:", 2263);


### PR DESCRIPTION
The file asciilogo.txt is moving from arduino.cc to a different domain arduino.tips hence we need to change examples.